### PR TITLE
Improve package push flow

### DIFF
--- a/.github/workflows/create_go_package.yml
+++ b/.github/workflows/create_go_package.yml
@@ -16,30 +16,41 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - name: Checkout main branch
         uses: actions/checkout@v3
         with:
           ref: main
 
+      - name: Define global config git
+        run: |
+          git config --global user.name "Github Actions"
+          git config --global user.email "github-action@users.noreply.github.com"
+
       - name: Zip Go files
         run: |
           zip -r ../go.zip go
-
-      - name: Checkout packages branch
-        uses: actions/checkout@v3
-        with:
-          ref: packages
 
       - name: Move zip Go file to workspace
         run: |
           mv ../go.zip .
 
-      - name: Push zip Go file to packages branch
+      - name: Push zip Go file to new branch
         run: |
-          git config --global user.name "Github Actions"
-          git config --global user.email "github-action@users.noreply.github.com"
           git add go.zip
-          git commit -m "Added new Go package: '${{ github.event.pull_request.title }}'"
-          git push
+          git commit -am "Added new Go package: '${{ github.event.pull_request.title }}'"
 
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          base: main
+          branch: feature/go-pr_${{ github.event.pull_request.number }}-${{ github.event.created_at }}
+          branch-suffix: timestamp
+          committer: 'Github Actions <github-action@users.noreply.github.com>'
+          author: 'Github Actions <github-action@users.noreply.github.com>'
+          title: ${{ github.event.pull_request.title }}
+          body: ${{ github.event.pull_request.body }}
+          labels: |
+            go
+            automated pr

--- a/.github/workflows/create_java_package.yml
+++ b/.github/workflows/create_java_package.yml
@@ -4,8 +4,7 @@ on:
   pull_request:
     types:
       - closed
-    branches:
-      - 'main'
+    branches:s      - 'main'
     paths:
       - 'java/**'
 
@@ -16,31 +15,41 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - name: Checkout main branch
         uses: actions/checkout@v3
         with:
           ref: main
 
+      - name: Define global config git
+        run: |
+          git config --global user.name "Github Actions"
+          git config --global user.email "github-action@users.noreply.github.com"
+
       - name: Zip Java files
         run: |
            zip -r ../java.zip java
-
-      - name: Checkout packages branch
-        uses: actions/checkout@v3
-        with:
-          ref: packages
 
       - name: Move zip Java file to workspace
         run: |
           mv ../java.zip .
 
-      - name: Push zip Java file to packages branch
+      - name: Push zip Java file to new branch
         run: |
-          git config --global user.name "Github Actions"
-          git config --global user.email "github-action@users.noreply.github.com"
           git add java.zip
-          git commit -m "Added new Java package: '${{ github.event.pull_request.title }}'"
-          git push
+          git commit -am "Added new Java package: '${{ github.event.pull_request.title }}'"
           
-  
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          base: main
+          branch: feature/java-pr_${{ github.event.pull_request.number }}-${{ github.event.created_at }}
+          branch-suffix: timestamp
+          committer: 'Github Actions <github-action@users.noreply.github.com>'
+          author: 'Github Actions <github-action@users.noreply.github.com>'
+          title: ${{ github.event.pull_request.title }}
+          body: ${{ github.event.pull_request.body }}
+          labels: |
+            java
+            automated pr

--- a/.github/workflows/create_net_package.yml
+++ b/.github/workflows/create_net_package.yml
@@ -16,31 +16,41 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - name: Checkout main branch
         uses: actions/checkout@v3
         with:
           ref: main
 
+      - name: Define global config git
+        run: |
+          git config --global user.name "Github Actions"
+          git config --global user.email "github-action@users.noreply.github.com"
+
       - name: Zip .Net files
         run: |
            zip -r ../net.zip net
-
-      - name: Checkout packages branch
-        uses: actions/checkout@v3
-        with:
-          ref: packages
 
       - name: Move zip .Net file to workspace
         run: |
           mv ../net.zip .
 
-      - name: Push zip .Net file to packages branch
+      - name: Push zip .Net file to new branch
         run: |
-          git config --global user.name "Github Actions"
-          git config --global user.email "github-action@users.noreply.github.com"
           git add net.zip
-          git commit -m "Added new .Net package: '${{ github.event.pull_request.title }}'"
-          git push
+          git commit -am "Added new .Net package: '${{ github.event.pull_request.title }}'"
           
-  
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          base: main
+          branch: feature/net-pr_${{ github.event.pull_request.number }}-${{ github.event.created_at }}
+          branch-suffix: timestamp
+          committer: 'Github Actions <github-action@users.noreply.github.com>'
+          author: 'Github Actions <github-action@users.noreply.github.com>'
+          title: ${{ github.event.pull_request.title }}
+          body: ${{ github.event.pull_request.body }}
+          labels: |
+            net
+            automated pr

--- a/.github/workflows/create_node_package.yml
+++ b/.github/workflows/create_node_package.yml
@@ -16,20 +16,21 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - name: Checkout main branch
         uses: actions/checkout@v3
         with:
           ref: main
 
+      - name: Define global config git
+        run: |
+          git config --global user.name "Github Actions"
+          git config --global user.email "github-action@users.noreply.github.com"
+
       - name: Zip Node files
         run: |
            zip -r ../node.zip node
-
-      - name: Checkout packages branch
-        uses: actions/checkout@v3
-        with:
-          ref: packages
 
       - name: Move zip Node file to workspace
         run: |
@@ -37,10 +38,19 @@ jobs:
 
       - name: Push zip Node file to packages branch
         run: |
-          git config --global user.name "Github Actions"
-          git config --global user.email "github-action@users.noreply.github.com"
           git add node.zip
-          git commit -m "Added new Node package: '${{ github.event.pull_request.title }}'"
-          git push
+          git commit -am "Added new Node package: '${{ github.event.pull_request.title }}'"
           
-  
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          base: main
+          branch: feature/node-pr_${{ github.event.pull_request.number }}-${{ github.event.created_at }}
+          branch-suffix: timestamp
+          committer: 'Github Actions <github-action@users.noreply.github.com>'
+          author: 'Github Actions <github-action@users.noreply.github.com>'
+          title: ${{ github.event.pull_request.title }}
+          body: ${{ github.event.pull_request.body }}
+          labels: |
+            node
+            automated pr

--- a/.github/workflows/create_php_package.yml
+++ b/.github/workflows/create_php_package.yml
@@ -16,31 +16,42 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - name: Checkout main branch
         uses: actions/checkout@v3
         with:
           ref: main
 
+      - name: Define global config git
+        run: |
+          git config --global user.name "Github Actions"
+          git config --global user.email "github-action@users.noreply.github.com"
+
       - name: Zip PHP files
         run: |
            zip -r ../php.zip php
-
-      - name: Checkout packages branch
-        uses: actions/checkout@v3
-        with:
-          ref: packages
 
       - name: Move zip PHP file to workspace
         run: |
           mv ../php.zip .
 
-      - name: Push zip PHP file to packages branch
+      - name: Push zip PHP file to new branch
         run: |
-          git config --global user.name "Github Actions"
-          git config --global user.email "github-action@users.noreply.github.com"
           git add php.zip
-          git commit -m "Added new PHP package: '${{ github.event.pull_request.title }}'"
-          git push
-          
+          git commit -am "Added new PHP package: '${{ github.event.pull_request.title }}'"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          base: main
+          branch: feature/php-pr_${{ github.event.pull_request.number }}-${{ github.event.created_at }}
+          branch-suffix: timestamp
+          committer: 'Github Actions <github-action@users.noreply.github.com>'
+          author: 'Github Actions <github-action@users.noreply.github.com>'
+          title: ${{ github.event.pull_request.title }}
+          body: ${{ github.event.pull_request.body }}
+          labels: |
+            php
+            automated pr
   

--- a/.github/workflows/create_python_package.yml
+++ b/.github/workflows/create_python_package.yml
@@ -16,31 +16,41 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - name: Checkout main branch
         uses: actions/checkout@v3
         with:
           ref: main
 
+      - name: Define global config git
+        run: |
+          git config --global user.name "Github Actions"
+          git config --global user.email "github-action@users.noreply.github.com"
+
       - name: Zip Python files
         run: |
            zip -r ../python.zip python
-
-      - name: Checkout packages branch
-        uses: actions/checkout@v3
-        with:
-          ref: packages
 
       - name: Move zip Python file to workspace
         run: |
           mv ../python.zip .
 
-      - name: Push zip Python file to packages branch
+      - name: Push zip Python file to new branch
         run: |
-          git config --global user.name "Github Actions"
-          git config --global user.email "github-action@users.noreply.github.com"
           git add python.zip
-          git commit -m "Added new Python package: '${{ github.event.pull_request.title }}'"
-          git push
+          git commit -am "Added new Python package: '${{ github.event.pull_request.title }}'"
           
-  
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          base: main
+          branch: feature/python-pr_${{ github.event.pull_request.number }}-${{ github.event.created_at }}
+          branch-suffix: timestamp
+          committer: 'Github Actions <github-action@users.noreply.github.com>'
+          author: 'Github Actions <github-action@users.noreply.github.com>'
+          title: ${{ github.event.pull_request.title }}
+          body: ${{ github.event.pull_request.body }}
+          labels: |
+            python
+            automated pr

--- a/.github/workflows/create_ruby_package.yml
+++ b/.github/workflows/create_ruby_package.yml
@@ -16,30 +16,41 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - name: Checkout main branch
         uses: actions/checkout@v3
         with:
           ref: main
 
+      - name: Define global config git
+        run: |
+          git config --global user.name "Github Actions"
+          git config --global user.email "github-action@users.noreply.github.com"
+
       - name: Zip Ruby files
         run: |
            zip -r ../ruby.zip ruby
-
-      - name: Checkout packages branch
-        uses: actions/checkout@v3
-        with:
-          ref: packages
 
       - name: Move zip Ruby file to workspace
         run: |
           mv ../ruby.zip .
 
-      - name: Push zip Ruby file to packages branch
+      - name: Push zip Ruby file to new branch
         run: |
-          git config --global user.name "Github Actions"
-          git config --global user.email "github-action@users.noreply.github.com"
           git add ruby.zip
-          git commit -m "Added new Ruby package: '${{ github.event.pull_request.title }}'"
-          git push
+          git commit -am "Added new Ruby package: '${{ github.event.pull_request.title }}'"
 
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          base: main
+          branch: feature/ruby-pr_${{ github.event.pull_request.number }}-${{ github.event.created_at }}
+          branch-suffix: timestamp
+          committer: 'Github Actions <github-action@users.noreply.github.com>'
+          author: 'Github Actions <github-action@users.noreply.github.com>'
+          title: ${{ github.event.pull_request.title }}
+          body: ${{ github.event.pull_request.body }}
+          labels: |
+            ruby
+            automated pr

--- a/.gitignore
+++ b/.gitignore
@@ -6,13 +6,3 @@ npm-debug.log
 package-lock.json
 yarn.lock
 *.idea
-
-## PHP
-.php_cs.cache
-phpunit.xml
-.phpunit.result.cache
-composer.lock
-composer.phar
-*.iml
-*.log
-*vendor/


### PR DESCRIPTION
When a PR for changes on samples happen, instead of creating the zip file and push directly to packages branch. create a branch and PR to add this package update.