### PR TITLE
Bump Rack to version 2.2.6.4 or higher

### DIFF
--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    checkout_sdk (1.0.3)
+    checkout_sdk (1.1.1)
       faraday (>= 1.10.0)
       faraday-follow_redirects (~> 0.3.0)
       faraday-multipart (~> 1.0.4)
@@ -16,7 +16,7 @@ GEM
     faraday-net_http (3.0.2)
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2022.0105)
+    mime-types-data (3.2023.0218.1)
     multipart-post (2.3.0)
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
@@ -32,10 +32,11 @@ GEM
     tilt (2.0.11)
 
 PLATFORMS
+  universal-darwin-22
   x86_64-darwin-21
 
 DEPENDENCIES
-  checkout_sdk (~> 1.0, >= 1.0.3)
+  checkout_sdk (~> 1.1, >= 1.1.1)
   sinatra
 
 BUNDLED WITH


### PR DESCRIPTION
- Bump Rack to version 2.2.6.4 or higher
https://github.com/checkout/sdk-samples/security/dependabot/7